### PR TITLE
Fixed a bug where custom fields are not showing in checkout page

### DIFF
--- a/inc/Pages/ProfileSettings.php
+++ b/inc/Pages/ProfileSettings.php
@@ -187,7 +187,12 @@ class ProfileSettings {
 	 * @return array $checkout_fields Updated checkout fields
 	 */
 	public function smaily_checkout_fields( $checkout_fields ) {
+		// Get available account fields.
 		$fields = $this->smaily_get_account_fields();
+		// Fields to append to billing information.
+		$billing_details_list = [ 'user_gender', 'user_phone', 'user_dob', 'user_url' ];
+		// Fields to append to Additional information.
+		$order_details_list = [ 'user_newsletter' ];
 
 		foreach ( $fields as $key => $field_args ) {
 
@@ -195,7 +200,14 @@ class ProfileSettings {
 				continue;
 			}
 
-			$checkout_fields['account'][ $key ] = $field_args;
+			// Append billing details to customer billing details list.
+			if ( in_array( $key, $billing_details_list, true ) ) {
+				$checkout_fields['billing'][ $key ] = $field_args;
+			}
+			// Append newsletter to additional information.
+			if ( in_array( $key, $order_details_list, true ) ) {
+				$checkout_fields['order'][ $key ] = $field_args;
+			}
 		}
 
 		return $checkout_fields;

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 5.6
 Requires at least: 4.0
 Tested up to: 5.0.2
 WC tested up to: 3.5.3
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv3
 
 Simple and flexible Smaily newsletter and rss-feed integration for WooCommerce.
@@ -93,6 +93,10 @@ Cron update data-log is stored in the root folder of Smaily plugin, inside "smai
 4. WooCommerce Smaily RSS-feed screen.
 
 == Changelog ==
+
+### 1.0.2
+
+- Fixed a bug where custom fields are not showing in checkout page.
 
 ### 1.0.1
 

--- a/smaily-for-woocommerce.php
+++ b/smaily-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name: Smaily for WooCommerce
  * Plugin URI: https://github.com/sendsmaily/smaily-woocommerce-plugin
  * Description: Smaily email marketing and automation extension plugin for WooCommerce (set up opt-in form, client sync and output RSS-feed) for easy product import into template.
- * Version: 1.0.1
+ * Version: 1.0.2
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/


### PR DESCRIPTION
Somehow fields append to account array were not shown. Switched to using `billing` section for customer related fields and `order` section for newsletter subscription checkbox. 

Guest who don't register are also sent as subscribers to Smaily when subscribe newsletter checkbox is checked in checkout page.