### PR TITLE
Autoresponder validation automatic when allready saved.

### DIFF
--- a/inc/Api/Api.php
+++ b/inc/Api/Api.php
@@ -62,9 +62,6 @@ class Api {
 					$api_call = wp_remote_get(
 						'https://' . $sanitized['subdomain'] . '.sendsmaily.net/api/autoresponder.php',
 						[
-							'page'    => 1,
-							'limit'   => 100,
-							'status'  => [ 'ACTIVE' ],
 							'headers' => array(
 								'Authorization' => 'Basic ' . base64_encode( $sanitized['username'] . ':' . $sanitized['password'] ),
 							),
@@ -76,6 +73,9 @@ class Api {
 					// Show error message if no access.
 					if ( $http_code === 401 ) {
 						$response = array( 'error' => 'Invalid API credentials, no connection !' );
+					}
+					if ( is_wp_error( $api_call ) ) {
+						$response = array( 'error' => $api_call->get_error_message() );
 					}
 					// Return autoresponders list back to front end for selection.
 					if ( $http_code === 200 ) {

--- a/inc/Base/Enqueue.php
+++ b/inc/Base/Enqueue.php
@@ -29,7 +29,7 @@ class Enqueue {
 	 */
 	public function enqueue_admin_scripts() {
 		// enque css and js.
-		wp_enqueue_script( 'mypluginscript', SMAILY_PLUGIN_URL . 'static/javascript.js', array( 'jquery' ), '1.0.0', true );
+		wp_enqueue_script( 'mypluginscript', SMAILY_PLUGIN_URL . 'static/javascript.js', array( 'jquery' ), '1.1.0', true );
 		wp_enqueue_style( 'mypluginstyle', SMAILY_PLUGIN_URL . 'static/admin-style.css', array(), '1.0.0' );
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -85,6 +85,14 @@ Cron update data-log is stored in the root folder of Smaily plugin, inside "smai
 
 ## Changelog
 
+### 1.0.3
+
+- Settings form credentials are being validated automatically when allready in database
+
+### 1.0.2
+
+- Fixed a bug where custom fields are not showing in checkout page
+
 ### 1.0.1
 
 - Folder structure changed for CSS and JS

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 5.6
 Requires at least: 4.0
 Tested up to: 5.0.2
 WC tested up to: 3.5.3
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv3
 
 Simple and flexible Smaily newsletter and rss-feed integration for WooCommerce.
@@ -93,6 +93,10 @@ Cron update data-log is stored in the root folder of Smaily plugin, inside "smai
 4. WooCommerce Smaily RSS-feed screen.
 
 == Changelog ==
+
+### 1.0.3
+
+- Settings form credentials are being validated automatically when allready in database
 
 ### 1.0.2
 

--- a/static/javascript.js
+++ b/static/javascript.js
@@ -1,36 +1,46 @@
+"use strict";
+
 (function($) {
-  // First Form on Settings page to check if subdomain / username / password are correct.
-  $().ready(function() {
-    $("#startupForm").submit(function(e) {
-      e.preventDefault();
-
-      const spinner = $(".loader");
-      const advancedForm = $("#advancedForm");
-      const loaderWraper = $(".loader-wraper");
-
+  // Check if autoresponder data is allready validated.
+  $(window).on("load", function() {
+    // Form elements.
+    var spinner = $(".loader");
+    var advancedForm = $("#advancedForm");
+    var startupForm = $("#startupForm");
+    var loaderWraper = $(".loader-wraper");
+    // Smaily credentials.
+    var subdomain = $("#subdomain").val();
+    var username = $("#username").val();
+    var password = $("#password").val();
+    // Validate automatically if set.
+    if (subdomain != "" && username != "" && password != "") {
       // Show loading icon.
       spinner.show();
-      const $smly = $(this);
-
       // Call to WordPress API.
       $.post(
         ajaxurl,
         {
           action: "validate_api",
-          form_data: $smly.serialize()
+          form_data: startupForm.serialize()
         },
         function(response) {
-          const data = $.parseJSON(response);
+          var data = $.parseJSON(response);
           // Show Error messages to user if any exist.
           if (data["error"]) {
-            $errorMessage =
+            var errorMessage =
               '<div class = "error notice"><p>' + data["error"] + "</p></div>";
-            $(".message-display").html($errorMessage);
+            $(".message-display").html(errorMessage);
+            // Hide loading icon
+            spinner.hide();
+          } else if (!data) {
+            var errorMessage =
+              '<div class = "error notice"><p>Something went wrong with request to Smaily</p></div>"';
+            $(".message-display").html(errorMessage);
             // Hide loading icon
             spinner.hide();
           } else {
             // Add autoresponders to autoresponders list inside next form.
-            $.each(data, (index, item) => {
+            $.each(data, function(index, item) {
               $("#autoresponders-list").append(
                 $("<option>", {
                   value: JSON.stringify({ name: item["name"], id: item["id"] }),
@@ -38,7 +48,63 @@
                 })
               );
             });
+            // Hide validate button.
+            loaderWraper.hide();
+            // Show next form
+            advancedForm.show();
+            // Hide loading icon
+            spinner.hide();
+          }
+        }
+      );
+    }
+  });
 
+  // First Form on Settings page to check if subdomain / username / password are correct.
+  $().ready(function() {
+    $("#startupForm").submit(function(e) {
+      e.preventDefault();
+
+      var spinner = $(".loader");
+      var advancedForm = $("#advancedForm");
+      var loaderWraper = $(".loader-wraper");
+
+      // Show loading icon.
+      spinner.show();
+      var smly = $(this);
+
+      // Call to WordPress API.
+      $.post(
+        ajaxurl,
+        {
+          action: "validate_api",
+          form_data: smly.serialize()
+        },
+        function(response) {
+          var data = $.parseJSON(response);
+          // Show Error messages to user if any exist.
+          if (data["error"]) {
+            var errorMessage =
+              '<div class = "error notice"><p>' + data["error"] + "</p></div>";
+            $(".message-display").html(errorMessage);
+            // Hide loading icon
+            spinner.hide();
+          } else if (!data) {
+            var errorMessage =
+              '<div class = "error notice"><p>Something went wrong with request to Smaily</p></div>"';
+            $(".message-display").html(errorMessage);
+            // Hide loading icon
+            spinner.hide();
+          } else {
+            // Add autoresponders to autoresponders list inside next form.
+            $.each(data, function(index, item) {
+              $("#autoresponders-list").append(
+                $("<option>", {
+                  value: JSON.stringify({ name: item["name"], id: item["id"] }),
+                  text: item["name"]
+                })
+              );
+            });
             // Hide validate button.
             loaderWraper.hide();
             // Show next form
@@ -52,7 +118,7 @@
     });
 
     // Second form on settings page to save user info to database.
-    $("#advancedForm").submit(event => {
+    $("#advancedForm").submit(function(event) {
       event.preventDefault();
       // Scroll back to top if saved.
       $("html, body").animate(
@@ -61,8 +127,8 @@
         },
         "slow"
       );
-      const user_data = $("#startupForm").serialize();
-      const api_data = $("#advancedForm").serialize();
+      var user_data = $("#startupForm").serialize();
+      var api_data = $("#advancedForm").serialize();
       // Call to WordPress  API.
       $.post(
         ajaxurl,
@@ -75,18 +141,24 @@
         },
         function(response) {
           // Response message from back-end.
-          data = $.parseJSON(response);
+          var data = $.parseJSON(response);
           if (data["error"]) {
-            $errorMessage =
+            var errorMessage =
               '<div class = "error notice"><p>' + data["error"] + "</p></div>";
-            $(".message-display").html($errorMessage);
+            $(".message-display").html(errorMessage);
+          } else if (!data) {
+            var errorMessage =
+              '<div class = "error notice"><p>Something went wrong with request to Smaily</p></div>"';
+            $(".message-display").html(errorMessage);
+            // Hide loading icon
+            spinner.hide();
           } else {
             // Display message to user.
-            $successMessage =
+            var successMessage =
               '<div class = "notice notice-success is-dismissible"><p>' +
               data["success"] +
               "</p></div>";
-            $(".message-display").html($successMessage);
+            $(".message-display").html(successMessage);
           }
         }
       );

--- a/templates/smaily-woocommerce-admin.phtml
+++ b/templates/smaily-woocommerce-admin.phtml
@@ -6,6 +6,8 @@ $result= DataHandler::get_smaily_results();
 if( isset($result) ){
 	$result    = $result['result'];
 	$isEnabled = $result['enable'];
+	$autoresponder_name = $result['autoresponder'] ? $result['autoresponder'] : null;
+	$autoresponder_id = $result['autoresponder_id'] ? $result['autoresponder_id'] : null;
 }
 
 ?>
@@ -24,16 +26,16 @@ if( isset($result) ){
 				<tr class="form-field form-required">
 					<th scope="row"><label for="subdomain">Subdomain </label></th>
 					<td><input id="subdomain" name="subdomain" class="zoho_input" value="<?php echo ( $result['subdomain'] ) ? $result['subdomain'] : '';  ?>" type="text">
-					<small id="emailHelp" class="form-text text-muted"> For example "demo" from https://demo.sendsmaily.net/</small></td>
+					<small id="emailHelp" class="form-text text-muted"> For example <strong>"demo"</strong> from https://<strong>demo</strong>.sendsmaily.net/</small></td>
 				</tr>
 				<tr class="form-field form-required">
 					<th scope="row"><label for="username">API username </label></th>
-					<td><input name="username" class="zoho_input" value="<?php echo ( $result['username'] ) ? $result['username'] : ''; ?>" type="text">
+					<td><input id="username" name="username" class="zoho_input" value="<?php echo ( $result['username'] ) ? $result['username'] : ''; ?>" type="text">
 					</td>
 				</tr>
 				<tr class="form-field form-required">
 					<th scope="row"><label for="password">API password </label></th>
-					<td><input name="password" class="zoho_input" value="<?php echo ( $result['password'] ) ? $result['password'] : '';?>" type="password">
+					<td><input id="password" name="password" class="zoho_input" value="<?php echo ( $result['password'] ) ? $result['password'] : '';?>" type="password">
 					<small id="emailHelp" class="form-text text-muted"><a href="http://help.smaily.com/en/support/solutions/articles/16000062943-create-api-user" target="_blank">How to create API credentials?</a></small></td>
 				</tr> 
 			</tbody>
@@ -54,8 +56,14 @@ if( isset($result) ){
 			<tr class="form-field form-required">
 				<th scope="row"><label for="autoresponder">Autoresponder ID </label></th>
 				<td>
-					<select id="autoresponders-list" name="autoresponder" class="zoho_input" > 
-						<option value="">-Select-</option>
+					<select id="autoresponders-list" name="autoresponder" class="zoho_input" >
+						<?php 
+						if ( !empty( $autoresponder_name) && !empty( $autoresponder_id )) {
+							$autoresponder = ['name' => $autoresponder_name , 'id' => $autoresponder_id];
+							echo '<option value="' . htmlentities(json_encode($autoresponder)) . '">'. $autoresponder_name .' - (selected)</option>';
+						} else {
+							echo '<option value="">-Select-</option>';
+						}?>
 					</select>
 					<small id="emailHelp" class="form-text text-muted"><a href="http://help.smaily.com/en/support/solutions/articles/16000017234-creating-an-autoresponder" target="_blank">How to set up an autoresponder for confirmation emails?</a></small>
 				</td>


### PR DESCRIPTION
- Poped to version 1.0.3
- Updated readme.
- JS changed to ES5.
- All autoresponders are displayed in array
- Fixed a bug when validation passed with wrong details.

> If full url entered like `https://demo.sendsmaily.net/` then validation would pass because `wp_remote_retrieve_response_code method` returned ` WP Error` class. Now both cases are handled ( empty array and error class message)
https://github.com/sendsmaily/smaily-woocommerce-plugin/blob/d7e2343b45d992e1d2f541e0bb484565dd0a0f13/inc/Api/Api.php#L75
