### PR TITLE
Use bash as default shell handler

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -109,7 +109,7 @@ rm -f trunk/CHANGELOG.txt
 rm -f trunk/CONTRIBUTING.md
 rm -f trunk/CODE_OF_CONDUCT.md
 rm -f trunk/release.sh
-rm- f trunk/.vscode
+rm -f trunk/.vscode
 
 # DO THE ADD ALL NOT KNOWN FILES UNIX COMMAND
 svn add --force * --auto-props --parents --depth infinity -q

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # By Mike Jolley, based on work by Barry Kooij ;)
 # License: GPL v3
@@ -109,6 +109,7 @@ rm -f trunk/CHANGELOG.txt
 rm -f trunk/CONTRIBUTING.md
 rm -f trunk/CODE_OF_CONDUCT.md
 rm -f trunk/release.sh
+rm- f trunk/.vscode
 
 # DO THE ADD ALL NOT KNOWN FILES UNIX COMMAND
 svn add --force * --auto-props --parents --depth infinity -q


### PR DESCRIPTION
This shell-script uses `read -p` flag and you are not guaranteed to have bash extensions available.

This script will fail if `sh` is used and your system `sh` is not linked to `bash`.

Mine ubuntu uses `dash` for a link and it also fails to handle the `-p` tag.
![image](https://user-images.githubusercontent.com/22918359/73383646-5da6cf80-42d2-11ea-90d8-1bc5022bc207.png)
