### PR TITLE
Add directory check for release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -132,7 +132,10 @@ done
 
 # COPY TRUNK TO TAGS/$VERSION
 echo "Copying trunk to new tag"
-svn rm tags/${VERSION} || { echo "Failed to remove tag."; exit 1; }
+if [[ -d $TEMP_SVN_REPO/tags/${VERSION} ]];
+then
+    svn rm tags/${VERSION} || { echo "Failed to remove tag."; exit 1; }
+fi
 svn copy trunk tags/${VERSION} || { echo "Unable to create tag."; exit 1; }
 
 # DO SVN COMMIT


### PR DESCRIPTION
I think there is a problem with `realease.sh` script. Not so familiar with the SVN system but I think there's a logic mistake here.

I understand the last update to release script allows to change files under same release number in Wordpress SNV.

https://github.com/sendsmaily/smaily-woocommerce-plugin/blob/e2d1114eaf4438692bbdc384aeb954cb6fce3346/release.sh#L135

If a new version is submitted the tag would not exist. This will throw an error