### PR TITLE
Remove extra comma

### DIFF
--- a/inc/Base/Enqueue.php
+++ b/inc/Base/Enqueue.php
@@ -67,7 +67,7 @@ class Enqueue {
 		wp_localize_script(
 			'smailypluginscript',
 			'smaily_translations',
-			$translations,
+			$translations
 		);
 
 		// Settings for frontend JS.


### PR DESCRIPTION
Fixes error blocking 1.6.0 release to WordPress.org
```
PHP error in: smaily-for-woocommerce/tags/1.6.0/inc/Base/Enqueue.php:

Parse error: syntax error, unexpected ')' in Standard input code on line 71

```