### PR TITLE
Escaped '&' character caused base64 auth to fail

### DIFF
--- a/inc/Base/DataHandler.php
+++ b/inc/Base/DataHandler.php
@@ -34,6 +34,11 @@ class DataHandler {
 		// Escape db values for output and usage.
 		$result = [];
 		foreach ( $un_escaped_result as $key => $value ) {
+			// Smaily may include & in generated password. Don't convert & to HTML entity as it is used for Base64 authorization.
+			if ($key === 'password') {
+				$result[ $key ] = $value;
+				continue;
+			}
 			$result[ $key ] = esc_html( $value );
 		}
 

--- a/templates/smaily-woocommerce-admin.php
+++ b/templates/smaily-woocommerce-admin.php
@@ -134,7 +134,7 @@ $wc_categories_list = DataHandler::get_woocommerce_categories_list();
 						<input
 							id="password"
 							name="password"
-							value="<?php echo ( $result['password'] ) ? esc_html($result['password']) : ''; ?>"
+							value="<?php echo ( $result['password'] ) ? esc_html( $result['password'] ) : ''; ?>"
 							type="password">
 						<small id="password-help" class="form-text text-muted">
 							<a

--- a/templates/smaily-woocommerce-admin.php
+++ b/templates/smaily-woocommerce-admin.php
@@ -134,7 +134,7 @@ $wc_categories_list = DataHandler::get_woocommerce_categories_list();
 						<input
 							id="password"
 							name="password"
-							value="<?php echo ( $result['password'] ) ? $result['password'] : ''; ?>"
+							value="<?php echo ( $result['password'] ) ? esc_html($result['password']) : ''; ?>"
 							type="password">
 						<small id="password-help" class="form-text text-muted">
 							<a


### PR DESCRIPTION
closes #62

Previously all data was escaped for use. Set an exception for password field and moved escaping to template.