### PR TITLE
Wordpress 5.6 compatibility tested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
 ### 1.6.1
-- WordPress 5.6 compatibility. [issue #70](https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/70)
 - Improve naming of widget so it's more distinguishable. [issue #64](https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/64)
 - Bugfix - validate credentials fails if password contains '&' character. [issue #62](https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/62)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
 ### 1.6.1
+- WordPress 5.6 compatibility. [issue #70](https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/70)
 - Improve naming of widget so it's more distinguishable. [issue #64](https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/64)
 - Bugfix - validate credentials fails if password contains '&' character. [issue #62](https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/62)
+
 
 ### 1.6.0
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Smaily for WooCommerce ===
-Contributors: sendsmaily, kaarel, tomabel
+Contributors: sendsmaily, kaarel, tomabel, marispulk
 Tags: woocommerce, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.5
-Tested up to: 5.4.1
+Tested up to: 5.6.0
 WC tested up to: 4.1.0
 Stable tag: 1.6.1
 License: GPLv3


### PR DESCRIPTION
- Tested Wordpress 5.6.0 compatibility with Smaily for WooCommerce plugin.