### PR TITLE
WP version not 4.5 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Automatically subscribe newsletter subscribers to a Smaily subscribers list, gen
 
 ## Requirements
 
-Smaily for WooCommerce requires PHP 5.6+ (PHP 7.0+ recommended). You'll also need to be running WordPress 4.0+ and have WooCommerce 2.2+.
+Smaily for WooCommerce requires PHP 5.6+ (PHP 7.0+ recommended). You'll also need to be running WordPress 4.5+ and have WooCommerce 2.2+.
 
 ## Documentation & Support
 

--- a/readme.txt
+++ b/readme.txt
@@ -54,7 +54,7 @@ Automatically subscribe newsletter subscribers to a Smaily subscribers list, gen
 
 = Requirements =
 
-Smaily for WooCommerce requires PHP 5.6+ (PHP 7.0+ recommended). You'll also need to be running WordPress 4.0+ and have WooCommerce 2.2+.
+Smaily for WooCommerce requires PHP 5.6+ (PHP 7.0+ recommended). You'll also need to be running WordPress 4.5+ and have WooCommerce 2.2+.
 
 = Documentation & Support =
 


### PR DESCRIPTION
`Requires at least: `is correct but requirements section is not.
Ready for review