### PR TITLE
Use config authentication for phpMyAdmin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       - '8888:80'
     environment:
       PMA_HOST: wordpress_db
+      PMA_USER: root
+      PMA_PASSWORD: smailydev1
       MYSQL_ROOT_PASSWORD: smailydev1
 volumes:
   wordpress:


### PR DESCRIPTION
If login credentials are specified as environment variables, then phpMyAdmin will switch from cookie authentication to config authentication mode.

Instead of entering credentials, login will happen automatically when visiting phpMyAdmin.
Same as [#83 (WordPress)](https://github.com/sendsmaily/sendsmaily-wordpress-plugin/pull/83)