### PR TITLE
WordPress 5.7 compatibility tested

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, kaarel, tomabel, marispulk
 Tags: woocommerce, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.5
-Tested up to: 5.6.0
+Tested up to: 5.7.0
 WC tested up to: 4.7.0
 Stable tag: 1.7.0
 License: GPLv3


### PR DESCRIPTION
Tested WordPress 5.7 compatibility with Smaily for WooCommerce plugin.