### PR TITLE
1.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 1.7.1
+- Test compatibility with WordPress 5.7. [issue #88](https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/88)
+
 ### 1.7.0
 - Test compatibility with WordPress 5.6. [issue #70](https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/70)
 - Smaily plugin settings "General" tab refinement. [issue #72](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/72)

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: sendsmaily, kaarel, tomabel, marispulk
 Tags: woocommerce, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.5
-Tested up to: 5.6.0
+Tested up to: 5.7.0
 WC tested up to: 4.7.0
 Stable tag: 1.7.0
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 5.6
 Requires at least: 4.5
 Tested up to: 5.7.0
 WC tested up to: 4.7.0
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPLv3
 
 Simple and flexible Smaily newsletter and RSS-feed integration for WooCommerce.
@@ -145,6 +145,10 @@ Also you can determine if customer had more than 10 items in cart
 8. WooCommerce Smaily widget front screen.
 
 == Changelog ==
+
+= 1.7.1 = 
+
+- Test compatibility with WordPress 5.7.
 
 = 1.7.0 = 
 

--- a/smaily-for-woocommerce.php
+++ b/smaily-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name: Smaily for WooCommerce
  * Plugin URI: https://github.com/sendsmaily/smaily-woocommerce-plugin
  * Description: Smaily email marketing and automation extension plugin for WooCommerce. Set up easy sync for your contacts, add opt-in subscription form, import products directly to your email template and send abandoned cart reminder emails.
- * Version: 1.7.0
+ * Version: 1.7.1
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -53,7 +53,7 @@ use Smaily_Inc\Base\Cron;
 define( 'SMAILY_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SMAILY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SMAILY_PLUGIN_NAME', plugin_basename( __FILE__ ) );
-define( 'SMAILY_PLUGIN_VERSION', '1.7.0' );
+define( 'SMAILY_PLUGIN_VERSION', '1.7.1' );
 
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';


### PR DESCRIPTION
# Plugin Version : 1.7.1

**Version changelog**

A list of changes regarding the next version release:

1.WordPress 5.7 compatibility tested - [#89]

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated readme.txt
- [x] Updated CHANGELOG.md
- [x] Updated CONTRIBUTING.md
- [x] Updated plugin version number
- [x] Updated screenshots in assets folder
- [x] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
