### PR TITLE
RSS feed URL and template rendering improvements

### DIFF
--- a/inc/Base/DataHandler.php
+++ b/inc/Base/DataHandler.php
@@ -293,11 +293,13 @@ class DataHandler {
 	 * @param int $rss_limit Limit of products.
 	 * @param string $rss_order_by Order products by.
 	 * @param string $rss_order ASC/DESC order
-	 * @return string RSS URL e.g. example.com/smaily-rss-feed?category=uncategorized&limit=250
+	 * @return string
 	 */
 	public static function make_rss_feed_url( $rss_category = null, $rss_limit = null, $rss_order_by = null, $rss_order = null ) {
-		$parameters   = array();
-		$rss_url_base = get_site_url() . '/smaily-rss-feed/?';
+		global $wp_rewrite;
+
+		$site_url   = get_site_url( null, 'smaily-rss-feed' );
+		$parameters = array();
 
 		if ( isset( $rss_category ) && $rss_category !== '' ) {
 			$parameters['category'] = $rss_category;
@@ -308,12 +310,17 @@ class DataHandler {
 		if ( isset( $rss_order_by ) && $rss_order_by !== 'none' ) {
 			$parameters['order_by'] = $rss_order_by;
 		}
-		// Check if providing ?order is even necessary.
 		if ( isset( $rss_order ) && $rss_order_by !== 'none' && $rss_order_by !== 'rand' ) {
 			$parameters['order'] = $rss_order;
 		}
 
-		return add_query_arg( $parameters, get_site_url( null, 'smaily-rss-feed' ) );
+		// Handle URL when permalinks have not been enabled.
+		if ( $wp_rewrite->using_permalinks() === false ) {
+			$site_url                      = get_site_url();
+			$parameters['smaily-rss-feed'] = 'true';
+		}
+
+		return add_query_arg( $parameters, $site_url );
 	}
 
 }

--- a/inc/Rss/SmailyRss.php
+++ b/inc/Rss/SmailyRss.php
@@ -17,13 +17,9 @@ class SmailyRss {
 	 * @return void
 	 */
 	public function register() {
-		/* Rewrite Rules */
 		add_action( 'init', array( $this, 'smaily_rewrite_rules' ) );
-		/* Query Vars */
 		add_filter( 'query_vars', array( $this, 'smaily_register_query_var' ) );
-		/* Template Include */
-		add_filter( 'template_include', array( $this, 'smaily_rss_feed_template_include' ) );
-		/* Frontend settings */
+		add_filter( 'template_include', array( $this, 'smaily_rss_feed_template_include' ), 100 );
 		add_filter( 'smaily_settings', array( $this, 'smaily_rss_settings' ) );
 	}
 

--- a/inc/Rss/SmailyRss.php
+++ b/inc/Rss/SmailyRss.php
@@ -60,20 +60,19 @@ class SmailyRss {
 	 * @return string Updated template location
 	 */
 	public function smaily_rss_feed_template_include( $template ) {
-		global $wp_query; // Load $wp_query object.
-		if ( isset( $wp_query->query_vars['smaily-rss-feed'] ) ) {
-			// Check for query var "smaily-rss-feed".
-			$page_value = $wp_query->query_vars['smaily-rss-feed'];
-			// Verify "smaily-rss-feed" exists and value is "true".
-			if ( $page_value && $page_value === 'true' ) {
-				// Load your template or file.
-				return SMAILY_PLUGIN_PATH . 'templates/smaily-rss-feed.php';
-			}
-		}
-		// When rewrite rules database hasn't been refreshed yet.
-		if ( array_key_exists( 'pagename', $wp_query->query ) && $wp_query->query['pagename'] === 'smaily-rss-feed' ) {
+		$render_rss_feed = get_query_var( 'smaily-rss-feed', false );
+		$render_rss_feed = $render_rss_feed === 'true' ? '1' : $render_rss_feed;
+		$render_rss_feed = (bool) (int) $render_rss_feed;
+
+		$pagename = get_query_var( 'pagename' );
+
+		// Render products RSS feed, if requested.
+		if ( $render_rss_feed === true ) {
+			return SMAILY_PLUGIN_PATH . 'templates/smaily-rss-feed.php';
+		} elseif ( $pagename === 'smaily-rss-feed' ) {
 			return SMAILY_PLUGIN_PATH . 'templates/smaily-rss-feed.php';
 		}
+
 		// Load normal template as a fallback.
 		return $template;
 	}


### PR DESCRIPTION
- Feed URL generation takes account permalinks enabled state;
- RSS feed template rendering priority is moved to later stage;
- URL can now be rendered using `smaily-rss-feed=true` and `smaily-rss-feed=1` parameters.