### PR TITLE
Release 1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.11.2
+
+- Gracefully handle abandoned cart missing product [[#138](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/138)]
+
 ### 1.11.1
 
 - Handle missing customer data to reduce logged warnings and notices [[#135](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/135)]

--- a/inc/Base/Cron.php
+++ b/inc/Base/Cron.php
@@ -186,10 +186,14 @@ class Cron {
 			if ( ! empty( $selected_fields ) ) {
 				$products_data = [];
 				foreach ( $cart_data as $cart_item ) {
-					// Single product detais array.
 					$product = [];
+
 					// Get product details if selected from user settings.
 					$details = wc_get_product( $cart_item['product_id'] );
+					if ( ! $details ) {
+						continue;
+					}
+
 					foreach ( $selected_fields as $selected_field ) {
 						switch ( $selected_field ) {
 							case 'product_name':

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 5.6
 Requires at least: 4.5
 Tested up to: 5.8
 WC tested up to: 4.7.0
-Stable tag: 1.11.1
+Stable tag: 1.11.2
 License: GPLv3
 
 Simple and flexible Smaily newsletter and RSS-feed integration for WooCommerce.
@@ -150,6 +150,10 @@ Also you can determine if customer had more than 10 items in cart
 9. WooCommerce Smaily widget front screen.
 
 == Changelog ==
+
+= 1.11.2 =
+
+- Gracefully handle abandoned cart missing product
 
 = 1.11.1 =
 

--- a/smaily-for-woocommerce.php
+++ b/smaily-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name: Smaily for WooCommerce
  * Plugin URI: https://github.com/sendsmaily/smaily-woocommerce-plugin
  * Description: Smaily email marketing and automation extension plugin for WooCommerce. Set up easy sync for your contacts, add opt-in subscription form, import products directly to your email template and send abandoned cart reminder emails.
- * Version: 1.11.1
+ * Version: 1.11.2
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -48,7 +48,7 @@ define( 'SMAILY_PLUGIN_FILE', __FILE__ );
 define( 'SMAILY_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SMAILY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SMAILY_PLUGIN_NAME', plugin_basename( __FILE__ ) );
-define( 'SMAILY_PLUGIN_VERSION', '1.11.1' );
+define( 'SMAILY_PLUGIN_VERSION', '1.11.2' );
 
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';


### PR DESCRIPTION
- Gracefully handle abandoned cart missing product [[#138](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/138)]

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated readme.txt
- [x] Updated CHANGELOG.md
- [x] Updated CONTRIBUTING.md
- [x] Updated plugin version number
- [x] Ensure schema and data migrations are created
- [x] Updated screenshots in assets folder
- [x] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
