### PR TITLE
chore: Upgrade actions/cache to version 4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
       WP_PLUGIN_NAME: smaily-for-woocommerce
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         path: ${{ env.WP_PLUGIN_NAME }}
 


### PR DESCRIPTION
`actions/cache` version 1 and 2 are being sunset on the 1st February 2025.

You can read more about it [here](https://github.com/actions/cache/discussions/1510).