### PR TITLE
Fix: Fix broken third party styles and RSS feed URL generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### 1.22.1
 
-- Stop dequeueing 3rd party styles in module settings page
-- Fix RSS feed URL link not updating when updating form values
+- Stop dequeueing 3rd party styles in module settings page [[#147](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/147)]
+- Fix RSS feed URL link not updating when updating form values [[#147](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/147)]
 
 ### 1.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 1.22.1
+
+- Stop dequeueing 3rd party styles in module settings page
+- Fix RSS feed URL link not updating when updating form values
+
 ### 1.12.0
 
 - Include store URL in abandoned cart parameters [[#143](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/143)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### 1.22.1
+### 1.12.1
 
 - Stop dequeueing 3rd party styles in module settings page [[#147](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/147)]
 - Fix RSS feed URL link not updating when updating form values [[#147](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/147)]

--- a/inc/Base/Enqueue.php
+++ b/inc/Base/Enqueue.php
@@ -19,8 +19,6 @@ class Enqueue {
 		// add javascript and css files to plugin.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_front_scripts' ) );
-		// Must have low priority to dequeue successfully.
-		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_admin_styles' ), 100 );
 	}
 
 	/**
@@ -100,7 +98,7 @@ class Enqueue {
 		$default_settings = array();
 		$settings         = apply_filters( 'smaily_settings', $default_settings );
 		wp_add_inline_script(
-			'smaily_for_woocommerce-inline',
+			'smaily_for_woocommerce-admin_settings',
 			'var smaily_settings = ' . wp_json_encode( $settings ) . ';'
 		);
 	}
@@ -121,32 +119,4 @@ class Enqueue {
 		// Enqueue CSS.
 		wp_enqueue_style( 'smaily_for_woocommerce-front_style' );
 	}
-
-	/**
-	 * Dequeues all 3rd party styles on Smaily module settings page.
-	 * Note! This function can be removed once we decide to rework tabs to something other than jQuery UI
-	 *
-	 * @return void
-	 */
-	public function dequeue_admin_styles() {
-
-		$screen = get_current_screen();
-		if ( ! isset( $screen->base ) || $screen->base !== 'toplevel_page_smaily-settings' ) {
-			return;
-		}
-
-		$plugins_dir_url = content_url( 'plugins' );
-		$wp_styles       = wp_styles();
-		foreach ( $wp_styles->queue as $style_handle ) {
-			if ( strpos( $style_handle, 'smaily_for_woocommerce' ) === 0 ) {
-				continue;
-			}
-			$style_src_path = $wp_styles->registered[ $style_handle ]->src;
-
-			if ( strpos( $style_src_path, $plugins_dir_url ) === 0 ) {
-				wp_dequeue_style( $style_handle );
-			}
-		}
-	}
-
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Requires PHP: 5.6
 Requires at least: 4.5
 Tested up to: 6.7
 WC tested up to: 9.3.1
-Stable tag: 1.12.0
+Stable tag: 1.12.1
 License: GPLv3
 
 Simple and flexible Smaily newsletter and RSS-feed integration for WooCommerce.
@@ -150,6 +150,11 @@ Also you can determine if customer had more than 10 items in cart
 9. WooCommerce Smaily widget front screen.
 
 == Changelog ==
+
+= 1.12.1 =
+
+- Stop dequeuing 3rd party styles in module settings page.
+- Fixes RSS feed URL-s not updating when changing settings.
 
 = 1.12.0 =
 

--- a/smaily-for-woocommerce.php
+++ b/smaily-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name: Smaily for WooCommerce
  * Plugin URI: https://github.com/sendsmaily/smaily-woocommerce-plugin
  * Description: Smaily email marketing and automation extension plugin for WooCommerce. Set up easy sync for your contacts, add opt-in subscription form, import products directly to your email template and send abandoned cart reminder emails.
- * Version: 1.12.0
+ * Version: 1.12.1
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -48,7 +48,7 @@ define( 'SMAILY_PLUGIN_FILE', __FILE__ );
 define( 'SMAILY_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SMAILY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SMAILY_PLUGIN_NAME', plugin_basename( __FILE__ ) );
-define( 'SMAILY_PLUGIN_VERSION', '1.12.0' );
+define( 'SMAILY_PLUGIN_VERSION', '1.12.1' );
 
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';


### PR DESCRIPTION
# Plugin Version: 1.12.1

**Version changelog**

This PR does two things:
1. Stops dequeuing third party scripts on admin page. This change was added in #77 but it may break as many plugins as this change fixes. 
Issue described in: https://github.com/sendsmaily/smaily-woocommerce-plugin/issues/71

The fix is no longer required as the latest version of the Product Feed PRO for WooCommerce plugin no longer breaks styling of our plugin tabs. This change was also pushed by ElementsKit plugin styles breaking when viewing our plugin settings. If more such cases arise then we must implement more fine grained solution.

3. Fixes #120 as a side quest. Picking the low hanging fruits while here. The inline style handle was wrong and that caused the data not loaded that was required by the script.

**Release checklist**

- [x] Added `release` tag to this pull request
- [ ] Updated README.md
- [x] Updated readme.txt
- [x] Updated CHANGELOG.md
- [ ] Updated CONTRIBUTING.md
- [x] Updated plugin version number
- [ ] Ensure schema and data migrations are created
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
