### PR TITLE
release: Upgrade release action workflow to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         path: ${{ env.WP_PLUGIN_NAME }}
 
     - name: Setup Composer caching
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/composer-cache
         key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
Upgrades the actions/cache@v4 step in release workflow to v4. The old version is deprecated and building the release zip container fails.
