### PR TITLE
abandoned-cart: Add mandatory fields to abandoned cart payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### 1.12.2
+
+- Adds `"is_abandoned_cart" = "true"` field to abandoned cart automation payload
+- Does not opt-in customers who received abandoned cart email
+- WooCommerce 9.7 compatibility
+
 ### 1.12.1
 
 - Stop dequeueing 3rd party styles in module settings page [[#147](https://github.com/sendsmaily/smaily-woocommerce-plugin/pull/147)]

--- a/inc/Base/Cron.php
+++ b/inc/Base/Cron.php
@@ -238,8 +238,10 @@ class Cron {
 
 			// Query for Smaily autoresponder.
 			$query = [
-				'autoresponder' => $results['result']['cart_autoresponder_id'], // autoresponder ID.
-				'addresses'     => [ $addresses ],
+				'autoresponder'     => $results['result']['cart_autoresponder_id'], // autoresponder ID.
+				'addresses'         => [ $addresses ],
+				'force_opt_in'      => false,
+				'is_abandoned_cart' => true,
 			];
 			// Send data to Smaily.
 			$response = Api::ApiCall( 'autoresponder', '', [ 'body' => $query ], 'POST' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Tags: woocommerce, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.5
 Tested up to: 6.7
-WC tested up to: 9.3.1
-Stable tag: 1.12.1
+WC tested up to: 9.7
+Stable tag: 1.12.2
 License: GPLv3
 
 Simple and flexible Smaily newsletter and RSS-feed integration for WooCommerce.
@@ -150,6 +150,12 @@ Also you can determine if customer had more than 10 items in cart
 9. WooCommerce Smaily widget front screen.
 
 == Changelog ==
+
+= 1.12.2 =
+
+- Adds `"is_abandoned_cart" = "true"` field to abandoned cart automation payload
+- Does not opt-in customers who received abandoned cart email
+- WooCommerce 9.7 compatibility
 
 = 1.12.1 =
 

--- a/smaily-for-woocommerce.php
+++ b/smaily-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name: Smaily for WooCommerce
  * Plugin URI: https://github.com/sendsmaily/smaily-woocommerce-plugin
  * Description: Smaily email marketing and automation extension plugin for WooCommerce. Set up easy sync for your contacts, add opt-in subscription form, import products directly to your email template and send abandoned cart reminder emails.
- * Version: 1.12.1
+ * Version: 1.12.2
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -48,7 +48,7 @@ define( 'SMAILY_PLUGIN_FILE', __FILE__ );
 define( 'SMAILY_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SMAILY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SMAILY_PLUGIN_NAME', plugin_basename( __FILE__ ) );
-define( 'SMAILY_PLUGIN_VERSION', '1.12.1' );
+define( 'SMAILY_PLUGIN_VERSION', '1.12.2' );
 
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';


### PR DESCRIPTION


# Plugin Version : 1.12.2

**Version changelog**

A list of changes regarding the next version release:

1. This PR adds two mandatory fields to abandoned cart payload to better distinguish abandoned cart email receivers from regular subscribers. 
2. Also tested with latest WooCommerce version.

**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated readme.txt
- [x] Updated CHANGELOG.md
- [ ] Updated CONTRIBUTING.md
- [x] Updated plugin version number
- [ ] Ensure schema and data migrations are created
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
