### PR TITLE
widget: Fix text domain loading too early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 1.12.3
+
+- Fixes translations not correctly loaded due to widget translations were loaded too early in WordPress lifecycle.
+
 ### 1.12.2
 
 - Adds `"is_abandoned_cart" = "true"` field to abandoned cart automation payload

--- a/inc/Init.php
+++ b/inc/Init.php
@@ -27,7 +27,7 @@ final class Init {
 			Base\Cart::class,
 			Base\Cron::class,
 			Api\Api::class,
-			Widget\SmailyWidget::class,
+			Widget\Register::class,
 			Rss\SmailyRss::class,
 		);
 	}

--- a/inc/Widget/Register.php
+++ b/inc/Widget/Register.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package smaily_for_woocommerce
+ */
+
+namespace Smaily_Inc\Widget;
+
+class Register {
+	/**
+	 * Register plugin widgets.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_action( 'widgets_init', array( $this, 'register_widgets' ) );
+	}
+
+	/**
+	 * Register the Smaily widget.
+	 *
+	 * @return void
+	 */
+	public function register_widgets() {
+		register_widget( SmailyWidget::class );
+	}
+}

--- a/inc/Widget/SmailyWidget.php
+++ b/inc/Widget/SmailyWidget.php
@@ -24,22 +24,6 @@ class SmailyWidget extends \WP_Widget {
 	}
 
 	/**
-	 * Action hooks for initializing widget.
-	 *
-	 * @return void
-	 */
-	public function register() {
-
-		// Register widget for WordPress.
-		add_action(
-			'widgets_init',
-			function() {
-				register_widget( 'Smaily_Inc\Widget\SmailyWidget' );
-			}
-		);
-	}
-
-	/**
 	 * Front-end display of widget.
 	 *
 	 * @see WP_Widget::widget()

--- a/readme.txt
+++ b/readme.txt
@@ -3,9 +3,9 @@ Contributors: sendsmaily, kaarel, tomabel, marispulk
 Tags: woocommerce, smaily, newsletter, email
 Requires PHP: 5.6
 Requires at least: 4.5
-Tested up to: 6.7
+Tested up to: 6.8
 WC tested up to: 9.7
-Stable tag: 1.12.2
+Stable tag: 1.12.3
 License: GPLv3
 
 Simple and flexible Smaily newsletter and RSS-feed integration for WooCommerce.
@@ -150,6 +150,10 @@ Also you can determine if customer had more than 10 items in cart
 9. WooCommerce Smaily widget front screen.
 
 == Changelog ==
+
+= 1.12.3 =
+
+- Fixes translations not correctly loaded due to widget translations were loaded too early in WordPress lifecycle.
 
 = 1.12.2 =
 

--- a/smaily-for-woocommerce.php
+++ b/smaily-for-woocommerce.php
@@ -13,7 +13,7 @@
  * Plugin Name: Smaily for WooCommerce
  * Plugin URI: https://github.com/sendsmaily/smaily-woocommerce-plugin
  * Description: Smaily email marketing and automation extension plugin for WooCommerce. Set up easy sync for your contacts, add opt-in subscription form, import products directly to your email template and send abandoned cart reminder emails.
- * Version: 1.12.2
+ * Version: 1.12.3
  * License: GPL3
  * Author: Smaily
  * Author URI: https://smaily.com/
@@ -48,7 +48,7 @@ define( 'SMAILY_PLUGIN_FILE', __FILE__ );
 define( 'SMAILY_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SMAILY_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'SMAILY_PLUGIN_NAME', plugin_basename( __FILE__ ) );
-define( 'SMAILY_PLUGIN_VERSION', '1.12.2' );
+define( 'SMAILY_PLUGIN_VERSION', '1.12.3' );
 
 // Required to use functions is_plugin_active and deactivate_plugins.
 require_once ABSPATH . 'wp-admin/includes/plugin.php';


### PR DESCRIPTION
# Plugin Version: 1.12.3

**Version changelog**

Fixes text domain loading too early when initiating widget class. The widget class itself was instantiated during module initialization while registering services. This causes translation to be loaded too early as the widget constructor was called. To mitigate this, widgets should be self contained units not instantiated during boot up but passed as a class to the register function.


**Release checklist**

- [x] Added `release` tag to this pull request
- [x] Updated README.md
- [x] Updated readme.txt
- [x] Updated CHANGELOG.md
- [ ] Updated CONTRIBUTING.md
- [x] Updated plugin version number
- [ ] Ensure schema and data migrations are created
- [ ] Updated screenshots in assets folder
- [ ] Updated translations

**After PR merge**

- [ ] Released new version in GitHub
- [ ] Ran the `release.sh` script to publish plugin to WordPress plugin library
- [ ] Pinged code owners to inform marketing about new version
